### PR TITLE
Add new members to an existing cluster one by one.

### DIFF
--- a/etcd-cluster.yaml
+++ b/etcd-cluster.yaml
@@ -26,7 +26,7 @@ SenzaComponents:
       scalyr_account_key: '{{Arguments.ScalyrAccountKey}}'
     Type: Senza::TaupageAutoScalingGroup
     AutoScaling:
-      Minimum: 5 
+      Minimum: 5
       Maximum: 5
       MetricType: CPU
 SenzaInfo:

--- a/etcd-cluster.yaml
+++ b/etcd-cluster.yaml
@@ -26,8 +26,8 @@ SenzaComponents:
       scalyr_account_key: '{{Arguments.ScalyrAccountKey}}'
     Type: Senza::TaupageAutoScalingGroup
     AutoScaling:
-      Minimum: 3
-      Maximum: 3
+      Minimum: 5 
+      Maximum: 5
       MetricType: CPU
 SenzaInfo:
   Parameters:

--- a/etcd.py
+++ b/etcd.py
@@ -246,6 +246,9 @@ class EtcdCluster:
                 logging.warning('Member id=%s name=%s is not part of ASG', m.id, m.name)
                 logging.warning('Will wait until it would be removed from cluster by HouseKeeper job running on leader')
                 return False
+            if m.id and not m.name and not m.client_urls:
+                logging.warning('Member (id=%s peerURLs=%s) is registered but not yet joined', m.id, m.peer_urls)
+                return False
         return True
 
 

--- a/tests/test_etcd_cluster.py
+++ b/tests/test_etcd_cluster.py
@@ -2,7 +2,7 @@ import boto.ec2
 import requests
 import unittest
 
-from etcd import EtcdCluster, EtcdManager
+from etcd import EtcdCluster, EtcdManager, EtcdMember
 
 from test_etcd_manager import requests_get, boto_ec2_connect_to_region
 
@@ -32,9 +32,17 @@ class TestEtcdCluster(unittest.TestCase):
         self.cluster.load_members()
 
     def test_is_healthy(self):
-        self.assertFalse(self.cluster.is_healthy('123'))
+        me = EtcdMember({
+            'id': 'ifoobari7',
+            'name': 'i-sadfjhg',
+            'clientURLs': ['http://127.0.0.2:{}'.format(EtcdMember.DEFAULT_CLIENT_PORT)],
+            'peerURLs': ['http://127.0.0.2:{}'.format(EtcdMember.DEFAULT_PEER_PORT)],
+        })
+        self.assertFalse(self.cluster.is_healthy(me))
         self.cluster.members[-1].instance_id = 'foo'
         self.cluster.members[-1].name = ''
-        self.assertFalse(self.cluster.is_healthy('123'))
+        self.assertFalse(self.cluster.is_healthy(me))
+        self.cluster.members[-1].peer_urls = ['http://127.0.0.2:2380']
+        self.assertTrue(self.cluster.is_healthy(me))
         self.cluster.members.pop()
-        self.assertTrue(self.cluster.is_healthy('123'))
+        self.assertTrue(self.cluster.is_healthy(me))

--- a/tests/test_etcd_cluster.py
+++ b/tests/test_etcd_cluster.py
@@ -33,5 +33,8 @@ class TestEtcdCluster(unittest.TestCase):
 
     def test_is_healthy(self):
         self.assertFalse(self.cluster.is_healthy('123'))
+        self.cluster.members[-1].instance_id = 'foo'
+        self.cluster.members[-1].name = ''
+        self.assertFalse(self.cluster.is_healthy('123'))
         self.cluster.members.pop()
         self.assertTrue(self.cluster.is_healthy('123'))


### PR DESCRIPTION
Before sending add member command to an existing cluster we should check
that there is nobody already in process of adding itself to the cluster.

Basically this is just workaround for the following problem:
https://github.com/zalando/stups-etcd-cluster/issues/1

New members were added successfully but etcd failed to start due to
version incompatibility and we lost quorum.