### PR TITLE
remove add command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ EXPOSE 2379 2380
 ## Install etcd
 RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz | tar xz -C /bin --strip=1 --wildcards --no-anchored etcd etcdctl
 
-ADD etcd.py /bin/etcd.py
-
 WORKDIR $HOME
 USER ${USER}
 CMD ["/bin/etcd.py"]


### PR DESCRIPTION
before: 

```
stups master % docker build https://raw.githubusercontent.com/zalando/stups-etcd-cluster/master/Dockerfile
Downloading build context from remote url: https://raw.githubusercontent.com/zalando/stups-etcd-cluster/master/Dockerfile    640 B
Sending build context to Docker daemon  2.56 kB
Step 0 : FROM zalando/python:3.4.0-4
 ---> 5c1dd941fa13
Step 1 : MAINTAINER Alexander Kukushkin <alexander.kukushkin@zalando.de>
 ---> Using cache
 ---> b733bab6cb1e
Step 2 : ENV USER etcd
 ---> Using cache
 ---> 5b9166095ead
Step 3 : ENV HOME /home/${USER}
 ---> Using cache
 ---> f3fbf86ad5ba
Step 4 : ENV ETCDVERSION 2.2.1
 ---> Using cache
 ---> 347d072e2c8a
Step 5 : RUN useradd -d ${HOME} -k /etc/skel -s /bin/bash -m ${USER} && chmod 777 ${HOME}
 ---> Using cache
 ---> a748675864bd
Step 6 : RUN ln -s /usr/bin/python3 /usr/bin/python && pip3 install boto
 ---> Using cache
 ---> 9af89fec3815
Step 7 : EXPOSE 2379 2380
 ---> Using cache
 ---> 9fd024af2d97
Step 8 : RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz | tar xz -C /bin --strip=1 --wildcards --no-anchored etcd etcdctl
 ---> Using cache
 ---> 881f777d1814
Step 9 : ADD etcd.py /bin/etcd.py
etcd.py: no such file or directory

```

after:

```
stups-etcd-cluster master % docker build . 
Sending build context to Docker daemon 141.8 kB
Step 0 : FROM zalando/python:3.4.0-4
 ---> 5c1dd941fa13
Step 1 : MAINTAINER Alexander Kukushkin <alexander.kukushkin@zalando.de>
 ---> Using cache
 ---> b733bab6cb1e
Step 2 : ENV USER etcd
 ---> Using cache
 ---> 5b9166095ead
Step 3 : ENV HOME /home/${USER}
 ---> Using cache
 ---> f3fbf86ad5ba
Step 4 : ENV ETCDVERSION 2.2.1
 ---> Using cache
 ---> 347d072e2c8a
Step 5 : RUN useradd -d ${HOME} -k /etc/skel -s /bin/bash -m ${USER} && chmod 777 ${HOME}
 ---> Using cache
 ---> a748675864bd
Step 6 : RUN ln -s /usr/bin/python3 /usr/bin/python && pip3 install boto
 ---> Using cache
 ---> 9af89fec3815
Step 7 : EXPOSE 2379 2380
 ---> Using cache
 ---> 9fd024af2d97
Step 8 : RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz | tar xz -C /bin --strip=1 --wildcards --no-anchored etcd etcdctl
 ---> Using cache
 ---> 881f777d1814
Step 9 : WORKDIR $HOME
 ---> Running in 6fc130cd0275
 ---> d3f161b02032
Removing intermediate container 6fc130cd0275
Step 10 : USER ${USER}
 ---> Running in f1e5ea30ae85
 ---> 92ba1d519593
Removing intermediate container f1e5ea30ae85
Step 11 : CMD /bin/etcd.py
 ---> Running in 4c2e474921e7
 ---> 8612a9f9be84
Removing intermediate container 4c2e474921e7
Successfully built 8612a9f9be84
```