### PR TITLE
Explicitly allow etcd members to communicate with eachother.

### DIFF
--- a/etcd-cluster.yaml
+++ b/etcd-cluster.yaml
@@ -52,6 +52,20 @@ Resources:
         FromPort: 2379
         ToPort: 2380
         CidrIp: 0.0.0.0/0
+  EtcdIngressMembers:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      GroupId:
+        Fn::GetAtt:
+          - EtcdSecurityGroup
+          - GroupId
+      IpProtocol: tcp
+      FromPort: 0
+      ToPort: 65535
+      SourceSecurityGroupId:
+        Fn::GetAtt:
+          - EtcdSecurityGroup
+          - GroupId
   EtcdRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
Although in the default setup this does not really matter much, it allows people to reconfigure
the default access in a much more restrictive way.
By explicitly allowing the etcd members, this would be less cumbersome.