### PR TITLE
Base our Docker image on alpine instead of a big distribution.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zalando/python:3.5.0-3
+FROM alpine
 MAINTAINER Alexander Kukushkin <alexander.kukushkin@zalando.de>
 
 ENV USER etcd
@@ -6,18 +6,29 @@ ENV HOME /home/${USER}
 ENV ETCDVERSION 2.2.5
 
 # Create home directory for etcd
-RUN useradd -d ${HOME} -k /etc/skel -s /bin/bash -m ${USER} && chmod 777 ${HOME}
+RUN adduser -h ${HOME} -s /bin/bash -S ${USER} && chmod 777 ${HOME}
 
-# Install boto
-RUN pip3 install boto3
+RUN apk add --no-cache python3 curl ca-certificates bash
 
-EXPOSE 2379 2380
+## We do all these steps in one command to ensure the build-dependencies do
+## not make it into the Docker image
+RUN apk add --no-cache --virtual=build-dependencies \
+    && curl -L "https://bootstrap.pypa.io/get-pip.py" | python3 \
+    && pip3 install boto3 requests \
+    && apk del build-dependencies \
+    && rm -rf /var/cache/apk/*
 
 ## Install etcd
-RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz | tar xz -C /bin --strip=1 --wildcards --no-anchored etcd etcdctl
+RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz \
+    | tar xz -C /tmp \
+    && mv /tmp/etcd-v*/etcdctl /bin \
+    && mv /tmp/etcd-v*/etcd /bin \
+    && rm -rf /tmp/etcd-v*
+
+EXPOSE 2379 2380
 
 ADD etcd.py /bin/etcd.py
 
 WORKDIR $HOME
 USER ${USER}
-CMD ["/bin/etcd.py"]
+CMD ["python3" ,"/bin/etcd.py"]


### PR DESCRIPTION
By only packaging what we need, we can reduce the size of the Docker image from > 500MB to around 100MB.